### PR TITLE
Update VS Code Project Settings to v1.7.0

### DIFF
--- a/assets/embedded-riscv-ai85/templateMakefile.RISCV
+++ b/assets/embedded-riscv-ai85/templateMakefile.RISCV
@@ -97,8 +97,10 @@ STACK_SIZE=1024
 # "A2" in ASCII
 # TARGET_REV=0x4132
 
-# Use this variables to specify and alternate tool path
-#TOOL_DIR=/usr/local/riscv-none-embed-gcc/8.3.0-1.1
+# Use this variables to specify an alternate RISCV toolchain
+# For example, to use the (now deprecated) "riscv-none-embed"...
+# Note the toolchain must be on the PATH.
+#RISCV_PREFIX = riscv-none-embed
 
 # Point this variable to a startup file to override the default file
 #STARTUPFILE=startup_riscv_##__TARGET_LC__##.S

--- a/assets/embedded-riscv-ai87/templateMakefile.RISCV
+++ b/assets/embedded-riscv-ai87/templateMakefile.RISCV
@@ -97,8 +97,10 @@ STACK_SIZE=1024
 # "A2" in ASCII
 # TARGET_REV=0x4132
 
-# Use this variables to specify and alternate tool path
-#TOOL_DIR=/usr/local/riscv-none-embed-gcc/8.3.0-1.1
+# Use this variables to specify an alternate RISCV toolchain
+# For example, to use the (now deprecated) "riscv-none-embed"...
+# Note the toolchain must be on the PATH.
+#RISCV_PREFIX = riscv-none-embed
 
 # Point this variable to a startup file to override the default file
 #STARTUPFILE=startup_riscv_##__TARGET_LC__##.S

--- a/assets/vscode/defaults/settings.json
+++ b/assets/vscode/defaults/settings.json
@@ -1,16 +1,16 @@
 {    
     "terminal.integrated.env.windows": {
-        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:MSYS_path}/usr/bin;${config:Make_path};${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.defaultProfile.windows": "Command Prompt",
 
     "terminal.integrated.env.linux": {
-        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
 
@@ -28,12 +28,13 @@
     "RV_OCD_target_file":"${config:target}_riscv.cfg",
 
     "v_Arm_GCC":"10.3",
-    "v_xPack_GCC":"10.2.0-1.2",
+    "v_xPack_GCC":"12.2.0-3.1",
 
     "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
     "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
-    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
-    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-elf-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/GNUTools/Make",
+    "MSYS_path":"${config:MAXIM_PATH}/Tools/MSYS2",
 
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
@@ -47,6 +48,7 @@
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display/fonts",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
@@ -60,6 +62,7 @@
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display/fonts",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
@@ -67,6 +70,9 @@
         "${config:MAXIM_PATH}/Libraries/MiscDrivers"
     ],
     "C_Cpp.default.defines": [
-        "${config:board}"
+        
+    ],
+    "C_Cpp.default.forcedInclude": [
+        "${workspaceFolder}/build/project_defines.h"
     ]
 }

--- a/assets/vscode/template/.vscode/flash.gdb
+++ b/assets/vscode/template/.vscode/flash.gdb
@@ -1,5 +1,6 @@
 define flash_m4
     set architecture armv7e-m
+    set remotetimeout 10
     target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
     load
     compare-sections
@@ -8,6 +9,7 @@ end
 
 define flash_m4_run
     set architecture armv7e-m
+    set remotetimeout 10
     target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
     load
     compare-sections

--- a/assets/vscode/template/.vscode/launch.json
+++ b/assets/vscode/template/.vscode/launch.json
@@ -13,7 +13,7 @@
             "servertype": "openocd",
             "linux": {
                 "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
-                "serverpath": "${config:OCD_path}/openocd",
+                "serverpath": "${config:OCD_path}/openocd"
             },
             "windows": {
                 "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",

--- a/assets/vscode/template/.vscode/launch.json
+++ b/assets/vscode/template/.vscode/launch.json
@@ -21,7 +21,7 @@
             },
             "osx": {
                 "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
-                "serverpath": "${config:OCD_path}/openocd",
+                "serverpath": "${config:OCD_path}/openocd"
             },
             "searchDir": ["${config:OCD_path}/scripts"],
             "configFiles": ["interface/${config:M4_OCD_interface_file}", "target/${config:M4_OCD_target_file}"],
@@ -42,15 +42,15 @@
             "MIMode": "gdb",
             "linux": {
                 "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
-                "debugServerPath": "${config:OCD_path}/openocd",
+                "debugServerPath": "${config:OCD_path}/openocd"
             },
             "windows": {
                 "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
-                "debugServerPath": "${config:OCD_path}/openocd.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe"
             },
             "osx": {
                 "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
-                "debugServerPath": "${config:OCD_path}/bin/openocd",
+                "debugServerPath": "${config:OCD_path}/bin/openocd"
             },
             "logging": {
                 "exceptions": true,
@@ -92,15 +92,15 @@
             "MIMode": "gdb",
             "linux": {
                 "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/openocd",
+                "debugServerPath": "${config:OCD_path}/openocd"
             },
             "windows": {
                 "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb.exe",
-                "debugServerPath": "${config:OCD_path}/openocd.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe"
             },
             "osx": {
                 "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
-                "debugServerPath": "${config:OCD_path}/bin/openocd",
+                "debugServerPath": "${config:OCD_path}/bin/openocd"
             },
             "logging": {
                 "exceptions": true,

--- a/assets/vscode/template/.vscode/launch.json
+++ b/assets/vscode/template/.vscode/launch.json
@@ -1,6 +1,35 @@
 {
     "configurations": [
         {
+            "name": "Debug Arm (Cortex-debug)",
+            "cwd":"${workspaceRoot}",
+            "executable": "${workspaceFolder}/build/${config:program_file}",
+            "loadFiles": ["${workspaceFolder}/build/${config:program_file}"],
+            "symbolFiles": [{
+                "file": "${workspaceFolder}/build/${config:symbol_file}"
+            }],
+            "request": "launch",
+            "type": "cortex-debug",
+            "servertype": "openocd",
+            "linux": {
+                "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "serverpath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "serverpath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "serverpath": "${config:OCD_path}/openocd",
+            },
+            "searchDir": ["${config:OCD_path}/scripts"],
+            "configFiles": ["interface/${config:M4_OCD_interface_file}", "target/${config:M4_OCD_target_file}"],
+            "interface": "swd",
+            "runToEntryPoint": "main",
+            "svdFile": "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include/${config:target}.svd"
+        },
+        {
             "name": "GDB (Arm M4)",
             "type": "cppdbg",
             "request": "launch",
@@ -13,15 +42,15 @@
             "MIMode": "gdb",
             "linux": {
                 "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
-                "debugServerPath": "${config:OCD_path}/openocd"
+                "debugServerPath": "${config:OCD_path}/openocd",
             },
             "windows": {
                 "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
-                "debugServerPath": "${config:OCD_path}/openocd.exe"
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
             },
             "osx": {
                 "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
-                "debugServerPath": "${config:OCD_path}/bin/openocd"
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
             },
             "logging": {
                 "exceptions": true,
@@ -62,16 +91,16 @@
             "externalConsole": false,
             "MIMode": "gdb",
             "linux": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
-                "debugServerPath": "${config:OCD_path}/openocd"
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
             },
             "windows": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
-                "debugServerPath": "${config:OCD_path}/openocd.exe"
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
             },
             "osx": {
-                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
-                "debugServerPath": "${config:OCD_path}/bin/openocd"
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-elf-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
             },
             "logging": {
                 "exceptions": true,

--- a/assets/vscode/template/.vscode/launch.json
+++ b/assets/vscode/template/.vscode/launch.json
@@ -17,7 +17,7 @@
             },
             "windows": {
                 "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
-                "serverpath": "${config:OCD_path}/openocd.exe",
+                "serverpath": "${config:OCD_path}/openocd.exe"
             },
             "osx": {
                 "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",

--- a/assets/vscode/template/.vscode/tasks.json
+++ b/assets/vscode/template/.vscode/tasks.json
@@ -110,6 +110,6 @@
             ],
             "problemMatcher": [],
             "dependsOn":[]
-        },
+        }
     ]
 }

--- a/assets/vscode/template/.vscode/tasks.json
+++ b/assets/vscode/template/.vscode/tasks.json
@@ -4,21 +4,30 @@
         {
             "label": "build",
             "type": "shell",
-            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "command": "make -r -j 8 --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "osx":{
+                "command": "source ~/.zshrc && make -r -j 8 --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}"
+            },
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "clean",
             "type": "shell",
-            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "command": "make -j 8 clean --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "osx":{
+                "command": "source ~/.zshrc && make -j 8 clean --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}"
+            },
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "clean-periph",
             "type": "shell",
-            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "command": "make -j 8 distclean --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "osx":{
+                "command": "source ~/.zshrc && make -j 8 distclean --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}"
+            },
             "group": "build",
             "problemMatcher": []
         },
@@ -101,6 +110,6 @@
             ],
             "problemMatcher": [],
             "dependsOn":[]
-        }
+        },
     ]
 }

--- a/assets/vscode/template/.vscode/templatesettings.json
+++ b/assets/vscode/template/.vscode/templatesettings.json
@@ -1,16 +1,16 @@
 {
     "terminal.integrated.env.windows": {
-        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:MSYS_path}/usr/bin;${config:Make_path};${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.defaultProfile.windows": "Command Prompt",
-    
+
     "terminal.integrated.env.linux": {
-        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     "terminal.integrated.env.osx": {
-        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${config:Make_path}:${env:PATH}",
         "MAXIM_PATH":"${config:MAXIM_PATH}"
     },
     
@@ -34,6 +34,7 @@
     "ARM_GCC_path":"##__ARM_GCC_PATH__##",
     "xPack_GCC_path":"##__XPACK_GCC_PATH__##",
     "Make_path":"##__MAKE_PATH__##",
+    "MSYS_path":"##__MSYS_PATH__##",
 
     "C_Cpp.default.includePath": [
         "##__I_PATHS__##"
@@ -43,6 +44,9 @@
     ],
     "C_Cpp.default.defines": [
         "##__DEFINES__##"
+    ],
+    "C_Cpp.default.forcedInclude": [
+        "${workspaceFolder}/build/project_defines.h"
     ]
 }
 

--- a/izer/assets.py
+++ b/izer/assets.py
@@ -164,6 +164,7 @@ def vscode(
     arm_gcc_path: str = defaults["ARM_GCC_PATH"],
     xpack_gcc_path: str = defaults["XPACK_GCC_PATH"],
     make_path: str = defaults["MAKE_PATH"],
+    msys_path: str = defaults["MSYS_PATH"]
 ):
     """
     Generates Visual Studio Code project files from the VSCode-Maxim project.
@@ -247,7 +248,8 @@ def vscode(
                         replace("##__OCD_PATH__##", ocd_path). \
                         replace("##__ARM_GCC_PATH__##", arm_gcc_path). \
                         replace("##__XPACK_GCC_PATH__##", xpack_gcc_path). \
-                        replace("##__MAKE_PATH__##", make_path)
+                        replace("##__MAKE_PATH__##", make_path). \
+                        replace("##__MSYS_PATH__##", msys_path)
 
                 if (not out_file.exists()) or overwrite:
                     with open(out_file, "w+", encoding="UTF-8") as f:


### PR DESCRIPTION
This PR updates the VS Code project settings to the latest [VSCode-Maxim v1.7.0](https://github.com/analogdevicesinc/VSCode-Maxim/releases/tag/v1.7.0) files.

It also pulls in:
- [v1.6.0](https://github.com/analogdevicesinc/VSCode-Maxim/releases/tag/v1.6.0)
- [v1.6.1](https://github.com/analogdevicesinc/VSCode-Maxim/releases/tag/v1.6.1)
- [v1.6.2](https://github.com/analogdevicesinc/VSCode-Maxim/releases/tag/v1.6.2)

As reported in #346, the old template set up the user's PATH for the deprecated `riscv-none-embed` toolchain for the RISCV projects.  The updated project files set up the PATH correctly for `riscv-none-elf`, which is currently at v12.2 in the MSDK.

